### PR TITLE
Only extend un-serializable fields when updating fixture contents with user input

### DIFF
--- a/src/components/component-playground.jsx
+++ b/src/components/component-playground.jsx
@@ -361,8 +361,15 @@ module.exports = React.createClass({
         newState = {fixtureUserInput: userInput};
 
     try {
+      var originalFixtureContents =
+          this.constructor.getSelectedFixtureContents(this.props);
+
+      // We only want to extend Function props because they can't be serialized
+      // and they are not part of the editor's contents
       var fixtureContents =
-          _.cloneDeep(this.constructor.getSelectedFixtureContents(this.props));
+          _.pick(originalFixtureContents, function(value, key) {
+            return _.isFunction(value);
+          });
 
       if (userInput) {
         _.merge(fixtureContents, JSON.parse(userInput));

--- a/tests/components/component-playground/events.js
+++ b/tests/components/component-playground/events.js
@@ -294,6 +294,9 @@ describe('ComponentPlayground component', function() {
               fixtures: {
                 'simple state': {
                   defaultProp: true,
+                  unserializableProp: function() {
+                    // noop
+                  },
                   nested: {
                     nestedProp: true
                   }
@@ -309,11 +312,22 @@ describe('ComponentPlayground component', function() {
         render();
       });
 
-      it('should extend fixture contents with user input', function() {
+      it('should extend unserializable fixture contents with user input',
+         function() {
         triggerEditorChange('{"customProp": true}');
 
         expect(component.state.fixtureContents.customProp).to.equal(true);
-        expect(component.state.fixtureContents.defaultProp).to.equal(true);
+        expect(component.state.fixtureContents.unserializableProp).to.equal(
+            params.components.MyComponent.fixtures['simple state']
+                                         .unserializableProp);
+      });
+
+      it('should not extend serializable fixture contents with user input',
+         function() {
+        triggerEditorChange('{"customProp": true}');
+
+        expect(component.state.fixtureContents.customProp).to.equal(true);
+        expect(component.state.fixtureContents.defaultProp).to.equal(undefined);
       });
 
       it('should not alter the original fixture contents', function() {


### PR DESCRIPTION
Only [extend](https://github.com/skidding/react-component-playground/blob/352c6e42b71f173d79b4ba34b96b295de32309c6/src/components/component-playground.jsx#L299) un-serializable fields when updating fixture contents with user input (because otherwise you'll get the original fixture if you empty the editor)

How to replicate:
- Use the Flatris playground
- Copy the state of a playing FlatrisGame, after the first tetrimino falls
- Paste it over the fixture of a playing FlatrisGame and the active tetrimino grid from the fixture and the other state will merge