### PR TITLE
Use CSS Modules to avoid generic class names

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -32,7 +32,9 @@ module.exports = function(config) {
           loader: 'babel-loader'
         }, {
           test: /\.less$/,
-          loader: 'style-loader!css-loader!less-loader'
+          loader: 'style-loader!css-loader?modules&importLoaders=1' +
+              '&localIdentName=[name]__[local]___[hash:base64:5]' +
+              '!less-loader'
         }],
         postLoaders: [{
           test: /\.jsx?$/,

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "babel-loader": "^5.0.0",
     "chai": "^2.2.0",
     "coveralls": "^2.11.2",
-    "css-loader": "^0.10.1",
+    "css-loader": "^0.15.2",
     "esprima-fb": "^14001.1.0-dev-harmony-fb",
     "istanbul": "^0.3.13",
     "istanbul-instrumenter-loader": "^0.1.2",
@@ -39,7 +39,7 @@
     "react": "^0.13.1",
     "sinon": "^1.14.1",
     "sinon-chai": "^2.7.0",
-    "style-loader": "^0.10.1",
+    "style-loader": "^0.12.3",
     "webpack": "^1.8.2"
   },
   "peerDependencies": {

--- a/src/components/component-playground.jsx
+++ b/src/components/component-playground.jsx
@@ -415,7 +415,7 @@ module.exports = React.createClass({
     var classes = {};
     classes[style['component-fixture']] = true;
     classes[style.selected] = componentName === this.props.component &&
-                          fixtureName === this.props.fixture;
+                              fixtureName === this.props.fixture;
 
     return classNames(classes);
   },

--- a/src/components/component-playground.jsx
+++ b/src/components/component-playground.jsx
@@ -1,4 +1,4 @@
-require('./component-playground.less');
+var style = require('./component-playground.less');
 
 var _ = require('lodash'),
     React = require('react'),
@@ -121,19 +121,19 @@ module.exports = React.createClass({
   render: function() {
     var isFixtureSelected = this.constructor.isFixtureSelected(this.props);
 
-    var classes = classNames({
-      'component-playground': true,
-      'full-screen': this.props.fullScreen
-    });
+    var classes = {};
+    classes[style['component-playground']] = true;
+    classes[style['full-screen']]= this.props.fullScreen;
+    classes = classNames(classes);
 
     return (
       <div className={classes}>
-        <div className="left-nav">
-          <div className="header">
+        <div className={style['left-nav']}>
+          <div className={style.header}>
             {this._renderHomeButton()}
             {isFixtureSelected ? this._renderMenu() : null}
           </div>
-          <div className="fixtures">
+          <div className={style['fixtures']}>
             {this._renderFixtures()}
           </div>
         </div>
@@ -143,12 +143,12 @@ module.exports = React.createClass({
   },
 
   _renderFixtures: function() {
-    return <ul className="components">
+    return <ul className={style.components}>
       {_.map(this.props.components, function(component, componentName) {
 
-        return <li className="component" key={componentName}>
+        return <li className={style.component} key={componentName}>
           <p ref={'componentName-' + componentName}
-             className="component-name">{componentName}</p>
+             className={style['component-name']}>{componentName}</p>
           {this._renderComponentFixtures(componentName, component.fixtures)}
         </li>;
 
@@ -157,7 +157,7 @@ module.exports = React.createClass({
   },
 
   _renderComponentFixtures: function(componentName, fixtures) {
-    return <ul className="component-fixtures">
+    return <ul className={style['component-fixtures']}>
       {_.map(fixtures, function(props, fixtureName) {
 
         var fixtureProps = this._extendFixtureRoute({
@@ -190,12 +190,12 @@ module.exports = React.createClass({
   },
 
   _renderFixtureEditor: function() {
-    var editorClasses = classNames({
-      'fixture-editor': true,
-      'invalid-syntax': !this.state.isFixtureUserInputValid
-    });
+    var editorClasses = {};
+    editorClasses[style['fixture-editor']] =  true;
+    editorClasses[style['invalid-syntax']] = !this.state.isFixtureUserInputValid;
+    editorClasses = classNames(editorClasses);
 
-    return <div className="fixture-editor-outer">
+    return <div className={style['fixture-editor-outer']}>
       <textarea ref="editor"
                 className={editorClasses}
                 value={this.state.fixtureUserInput}
@@ -207,33 +207,34 @@ module.exports = React.createClass({
   },
 
   _renderHomeButton: function() {
-    var classes = classNames({
-      'button': true,
-      'play-button': true,
-      'selected-button': !this.constructor.isFixtureSelected(this.props)
-    });
+    var classes = {};
+    classes[style.button] = true;
+    classes[style['play-button']] = true;
+    classes[style['selected-button']] = !this.constructor.isFixtureSelected(this.props);
+
+    classes = classNames(classes);
 
     return <a ref="homeButton"
               className={classes}
               href={stringifyParams({})}
               onClick={this.props.router.routeLink}>
-      <span className="electron"></span>
+      <span className={style.electron}></span>
     </a>;
   },
 
   _renderMenu: function() {
-    return <p className="menu">
+    return <p className={style.menu}>
       {this._renderFixtureEditorButton()}
       {this._renderFullScreenButton()}
     </p>;
   },
 
   _renderFixtureEditorButton: function() {
-    var classes = classNames({
-      'button': true,
-      'fixture-editor-button': true,
-      'selected-button': this.props.editor
-    });
+    var classes = {};
+    classes[style.button] = true;
+    classes[style['fixture-editor-button']] = true;
+    classes[style['selected-button']] = this.props.editor;
+    classes = classNames(classes);
 
     var editorUrlProps = this._extendFixtureRoute({
       editor: !this.props.editor
@@ -251,7 +252,7 @@ module.exports = React.createClass({
       editor: false
     });
 
-    return <a className="button full-screen-button"
+    return <a className={style.button + ' ' + style['full-screen-button']}
               href={stringifyParams(fullScreenProps)}
               ref="fullScreenButton"
               onClick={this.props.router.routeLink}></a>;
@@ -390,20 +391,16 @@ module.exports = React.createClass({
   },
 
   _getContentFrameClasses: function() {
-    var classes = {
-      'content-frame': true,
-      'with-editor': this.props.editor
-    };
-
-    classes['orientation-' + this.state.orientation] = true;
-
+    var classes = {};
+    classes[style['content-frame']] = true;
+    classes[style['with-editor']] = this.props.editor;
+    classes[style['orientation-' + this.state.orientation]] = true;
     return classNames(classes);
   },
 
   _getPreviewClasses: function() {
-    var classes = {
-      'preview': true
-    };
+    var classes = {};
+    classes[style.preview] = true;
 
     if (this.props.containerClassName) {
       classes[this.props.containerClassName] = true;
@@ -413,11 +410,9 @@ module.exports = React.createClass({
   },
 
   _getFixtureClasses: function(componentName, fixtureName) {
-    var classes = {
-      'component-fixture': true
-    };
-
-    classes['selected'] = componentName === this.props.component &&
+    var classes = {};
+    classes[style['component-fixture']] = true;
+    classes[style.selected] = componentName === this.props.component &&
                           fixtureName === this.props.fixture;
 
     return classNames(classes);

--- a/src/components/component-playground.jsx
+++ b/src/components/component-playground.jsx
@@ -123,7 +123,7 @@ module.exports = React.createClass({
 
     var classes = {};
     classes[style['component-playground']] = true;
-    classes[style['full-screen']]= this.props.fullScreen;
+    classes[style['full-screen']] = this.props.fullScreen;
     classes = classNames(classes);
 
     return (
@@ -192,7 +192,8 @@ module.exports = React.createClass({
   _renderFixtureEditor: function() {
     var editorClasses = {};
     editorClasses[style['fixture-editor']] =  true;
-    editorClasses[style['invalid-syntax']] = !this.state.isFixtureUserInputValid;
+    editorClasses[style['invalid-syntax']] =
+      !this.state.isFixtureUserInputValid;
     editorClasses = classNames(editorClasses);
 
     return <div className={style['fixture-editor-outer']}>
@@ -210,7 +211,8 @@ module.exports = React.createClass({
     var classes = {};
     classes[style.button] = true;
     classes[style['play-button']] = true;
-    classes[style['selected-button']] = !this.constructor.isFixtureSelected(this.props);
+    classes[style['selected-button']] =
+      !this.constructor.isFixtureSelected(this.props);
 
     classes = classNames(classes);
 

--- a/tests/components/component-playground/default/render/dom.js
+++ b/tests/components/component-playground/default/render/dom.js
@@ -1,4 +1,5 @@
 var FIXTURE = 'default';
+var style = require('components/component-playground.less');
 
 describe(`ComponentPlayground (${FIXTURE}) Render DOM`, function() {
   var $ = require('jquery'),
@@ -47,7 +48,7 @@ describe(`ComponentPlayground (${FIXTURE}) Render DOM`, function() {
   });
 
   it('should not have full-screen class', function() {
-    expect($component.hasClass('full-screen')).to.equal(false);
+    expect($component.hasClass(style['full-screen'])).to.equal(false);
   });
 
   it('should not render full screen button', function() {
@@ -64,6 +65,6 @@ describe(`ComponentPlayground (${FIXTURE}) Render DOM`, function() {
 
   it('should add selected class on home button', function() {
     expect($(component.refs.homeButton.getDOMNode())
-           .hasClass('selected-button')).to.be.true;
+           .hasClass(style['selected-button'])).to.be.true;
   });
 });

--- a/tests/components/component-playground/full-screen/render/dom.js
+++ b/tests/components/component-playground/full-screen/render/dom.js
@@ -1,4 +1,5 @@
 var FIXTURE = 'full-screen';
+var style = require('components/component-playground.less');
 
 describe(`ComponentPlayground (${FIXTURE}) Render DOM`, function() {
   var render = require('tests/lib/render-component.js'),
@@ -14,6 +15,6 @@ describe(`ComponentPlayground (${FIXTURE}) Render DOM`, function() {
   });
 
   it('should add full-screen class', function() {
-    expect($component.hasClass('full-screen')).to.equal(true);
+    expect($component.hasClass(style['full-screen'])).to.equal(true);
   });
 });

--- a/tests/components/component-playground/selected-fixture-and-editor/render/dom.js
+++ b/tests/components/component-playground/selected-fixture-and-editor/render/dom.js
@@ -1,4 +1,6 @@
 var FIXTURE = 'selected-fixture-and-editor';
+var style = require('components/component-playground.less');
+console.log(style)
 
 describe(`ComponentPlayground (${FIXTURE}) Render DOM`, function() {
   var $ = require('jquery'),
@@ -20,12 +22,12 @@ describe(`ComponentPlayground (${FIXTURE}) Render DOM`, function() {
 
   it('should add editor class on content frame node', function() {
     expect($(component.refs.contentFrame.getDOMNode())
-           .hasClass('with-editor')).to.be.true;
+           .hasClass(style['with-editor'])).to.be.true;
   });
 
   it('should add selected class on editor button', function() {
     expect($(component.refs.editorButton.getDOMNode())
-           .hasClass('selected-button')).to.be.true;
+           .hasClass(style['selected-button'])).to.be.true;
   });
 
   it('should populate editor textarea from state', function() {
@@ -42,6 +44,6 @@ describe(`ComponentPlayground (${FIXTURE}) Render DOM`, function() {
     });
 
     expect($(component.refs.editor.getDOMNode())
-           .hasClass('invalid-syntax')).to.be.true;
+           .hasClass(style['invalid-syntax'])).to.be.true;
   });
 });

--- a/tests/components/component-playground/selected-fixture-and-editor/render/dom.js
+++ b/tests/components/component-playground/selected-fixture-and-editor/render/dom.js
@@ -1,6 +1,5 @@
 var FIXTURE = 'selected-fixture-and-editor';
 var style = require('components/component-playground.less');
-console.log(style)
 
 describe(`ComponentPlayground (${FIXTURE}) Render DOM`, function() {
   var $ = require('jquery'),

--- a/tests/components/component-playground/selected-fixture/render/dom.js
+++ b/tests/components/component-playground/selected-fixture/render/dom.js
@@ -1,4 +1,5 @@
 var FIXTURE = 'selected-fixture';
+var style = require('components/component-playground.less');
 
 describe(`ComponentPlayground (${FIXTURE}) Render DOM`, function() {
   var $ = require('jquery'),
@@ -18,7 +19,7 @@ describe(`ComponentPlayground (${FIXTURE}) Render DOM`, function() {
     var $contentFrame = $(component.refs.contentFrame.getDOMNode());
 
     expect($contentFrame.hasClass(
-        'orientation-' + component.state.orientation)).to.be.true;
+        style['orientation-' + component.state.orientation])).to.be.true;
   });
 
   it('should add container class on preview element', function() {
@@ -29,11 +30,12 @@ describe(`ComponentPlayground (${FIXTURE}) Render DOM`, function() {
 
   it('should remove selected class on home button', function() {
     expect($(component.refs.homeButton.getDOMNode())
-           .hasClass('selected-button')).to.be.false;
+           .hasClass(style['selected-button'])).to.be.false;
   });
 
   it('should add extra class to selected fixture', function() {
-    var $fixture = $component.find('.component-fixture.selected');
+    var classes = '.' + style['component-fixture'] + '.' + style.selected;
+    var $fixture = $component.find(classes);
 
     expect($fixture.length).to.equal(1);
     expect($fixture.text()).to.equal('default');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,9 @@ module.exports = {
       loader: 'babel-loader'
     }, {
       test: /\.less$/,
-      loader: 'style-loader!css-loader?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]!less-loader'
+      loader: 'style-loader!css-loader?modules&importLoaders=1' +
+              '&localIdentName=[name]__[local]___[hash:base64:5]' +
+              '!less-loader'
     }]
   },
   output: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = {
       loader: 'babel-loader'
     }, {
       test: /\.less$/,
-      loader: 'style-loader!css-loader!less-loader'
+      loader: 'style-loader!css-loader?modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]!less-loader'
     }]
   },
   output: {


### PR DESCRIPTION
Addresses https://github.com/skidding/react-component-playground/issues/23 
I had to refactor usage of classNames modules to support dynamic class names. A bit more verbose, but should work just as fine.