### PR TITLE
Add support for objects with toJSON methods

### DIFF
--- a/src/lib/is-serializable.js
+++ b/src/lib/is-serializable.js
@@ -8,7 +8,11 @@ exports.isSerializable = function(obj) {
       _.isString(obj)) {
     return true;
   }
-
+  
+  if (_.isFunction(obj.toJSON)) {
+    return true;
+  }
+  
   if (!_.isPlainObject(obj) &&
       !_.isArray(obj)) {
     return false;

--- a/src/lib/is-serializable.js
+++ b/src/lib/is-serializable.js
@@ -8,11 +8,11 @@ exports.isSerializable = function(obj) {
       _.isString(obj)) {
     return true;
   }
-  
+
   if (_.isFunction(obj.toJSON)) {
     return true;
   }
-  
+
   if (!_.isPlainObject(obj) &&
       !_.isArray(obj)) {
     return false;


### PR DESCRIPTION
Add support for objects which claim to know how to serialize themselves.

This allows these sorts of properties to at least show up in the editor,
even if they cannot be edited without a corresponding hook in `onFixtureChange`.